### PR TITLE
Change public API according the feedback from the draft.

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,6 +1,5 @@
 language = "C"
 include_guard = "__blazesym_h_"
-after_includes = "\n#define CFG_T_ELF 1\n#define CFG_T_KERNEL 2\n#define CFG_T_PROCESS 3\n#define CFG_T_PROCESS_KERNEL 4"
 
 [export]
 item_types = ["globals", "enums", "structs", "unions", "typedefs", "opaque", "functions"]

--- a/examples/addr2ln_sym.rs
+++ b/examples/addr2ln_sym.rs
@@ -27,8 +27,8 @@ fn main() {
     let addr = u64::from_str_radix(addr_str, 16).unwrap();
 
     let sym_files = [SymbolFileCfg::Elf { file_name: bin_name, loaded_address: 0 },
-		     SymbolFileCfg::Kernel { kallsyms: String::from("/proc/kallsyms"),
-						  kernel_image: kern_name }];
+		     SymbolFileCfg::Kernel { kallsyms: Some(String::from("/proc/kallsyms")),
+					     kernel_image: Some(kern_name) }];
     let resolver = BlazeSymbolizer::new().unwrap();
     let symlist = resolver.symbolize(&sym_files, &[addr]);
     if let Some(SymbolizedResult {symbol, start_address, path, line_no, column}) = &symlist[0] {


### PR DESCRIPTION
For Rust API,
 - find_symbol() return a struct intead of a tuple.
 - Remove the ProcessKernel variant from SymbolFileCfg.

For C API,
 - Change the type of sym_file_cfg::cfg_type to an enum type.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>